### PR TITLE
Change rapidjson dependency to leap libraries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/rapidjson"]
-	path = external/rapidjson
-	url = https://github.com/Tencent/rapidjson.git
 [submodule "external/eosjs_"]
 	path = external/eosjs
 	url = https://github.com/eosnetworkfoundation/mandel-eosjs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,13 +76,13 @@ add_test(NAME test_abieos_reflect COMMAND test_abieos_reflect)
 
 # Causes build issues on some platforms
 # add_executable(test_abieos_sanitize src/test.cpp src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-# target_include_directories(test_abieos_sanitize PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
+# target_include_directories(test_abieos_sanitize PRIVATE include external/outcome/single-header ../../libraries/rapidjson/include external/date/include)
 # target_link_libraries(test_abieos_sanitize abieos -fno-omit-frame-pointer -fsanitize=address,undefined ${CMAKE_THREAD_LIBS_INIT})
 # target_compile_options(test_abieos_sanitize PUBLIC -fno-omit-frame-pointer -fsanitize=address,undefined)
 # add_test(NAME test_abieos_sanitize COMMAND test_abieos_sanitize)
 
 # add_executable(fuzzer src/fuzzer.cpp src/abieos.cpp)
-# target_include_directories(fuzzer PRIVATE external/outcome/single-header external/rapidjson/include external/date/include)
+# target_include_directories(fuzzer PRIVATE external/outcome/single-header ../../libraries/rapidjson/include external/date/include)
 # target_link_libraries(fuzzer -fsanitize=fuzzer,address,undefined,signed-integer-overflow -fstandalone-debug ${CMAKE_THREAD_LIBS_INIT})
 # target_compile_options(fuzzer PRIVATE -fsanitize=fuzzer,address,undefined,signed-integer-overflow -fstandalone-debug)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include(GNUInstallDirs)
 add_library(abieos STATIC src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
 target_include_directories(abieos PUBLIC 
                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include" 
-                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include"
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../libraries/rapidjson/include"
                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 if(ABIEOS_NO_INT128)
@@ -48,7 +48,7 @@ endif()
 add_library(abieos_module MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
 target_include_directories(abieos_module PUBLIC 
                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include;" 
-                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include" 
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/../../libraries/rapidjson/include"
                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 target_link_libraries(abieos_module ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Due to https://github.com/AntelopeIO/leap/pull/25 requiring rapidjson, the rapidjson dependency from eos has been moved out of abieos and into leap. This PR cleans up abieos old way of doing things.