### PR TITLE
avoid using multi-character to improve portability and clean up warnings in doing so

### DIFF
--- a/src/template_test.cpp
+++ b/src/template_test.cpp
@@ -227,9 +227,13 @@ int main() {
    test(private_key{std::in_place_index<1>}, abi, new_abi);
    test(signature{std::in_place_index<0>}, abi, new_abi);
    test(signature{std::in_place_index<1>}, abi, new_abi);
-   test(symbol{unsigned('ZYX\x08')}, abi, new_abi);
-   test(symbol_code{unsigned('ZYXW')}, abi, new_abi);
-   test(asset{5, symbol{'ZYX\x08'}}, abi, new_abi);
+   // avoid using multichars to improve portability and clean up warnings
+   auto multichars_to_uint32 = [] ( char const v[5] ) constexpr -> uint32_t {
+      return (v[0] << 24) | (v[1] << 16) | (v[2] << 8) | v[3];
+   };
+   test(symbol{multichars_to_uint32("ZYX\x08")}, abi, new_abi);
+   test(symbol_code{multichars_to_uint32("ZYXW")}, abi, new_abi);
+   test(asset{5, symbol{multichars_to_uint32("ZYX\x08")}}, abi, new_abi);
    test(struct_type{}, abi, new_abi);
    test(struct_type{{1},2,3}, abi, new_abi);
    test(struct_type{{1,2},3,4.0}, abi, new_abi);


### PR DESCRIPTION
Multi-character is not defined by C++ standard and is implementation-defined: https://en.cppreference.com/w/cpp/language/character_literal.

Change to calculate the symbol value deterministically and at compile time in the same way as previous multi-character implementation. The newly added function `multichars_to_uint32` was tested in both `gcc` and `clang`.

Fix the following warnings:

```
/home/lh/work/leap-main/tests/abieos/src/template_test.cpp:230:25: warning: multi-  character character constant [-Wmultichar]
  230 |    test(symbol{unsigned('ZYX\x08')}, abi, new_abi);
      |                         ^~~~~~~~~
/home/lh/work/leap-main/tests/abieos/src/template_test.cpp:231:30: warning: multi-  character character constant [-Wmultichar]
  231 |    test(symbol_code{unsigned('ZYXW')}, abi, new_abi);
      |                              ^~~~~~
/home/lh/work/leap-main/tests/abieos/src/template_test.cpp:232:25: warning: multi-  character character constant [-Wmultichar]
  232 |    test(asset{5, symbol{'ZYX\x08'}}, abi, new_abi);
      |                         ^~~~~~~~~
```