### PR TITLE
work around test failure on ARM float min/max roundtrip to&from string in JSON parsing

### DIFF
--- a/include/eosio/from_json.hpp
+++ b/include/eosio/from_json.hpp
@@ -485,7 +485,12 @@ void from_json(float& result, S& stream) {
    std::string s(sv); // strtof expects a null-terminated string
    errno = 0;
    char* end;
+#if defined(__linux__) && defined(__aarch64__)
+   //work around test failure for float::min/max roundtrip to&from string
+   result = std::strtod(s.c_str(), &end);
+#else
    result = std::strtof(s.c_str(), &end);
+#endif
    check( !errno && end == s.c_str() + s.size(),
          convert_json_error(from_json_error::expected_number) );
 }


### PR DESCRIPTION
On ARM Linux, even with latest gcc12, `strtof()` is returning an out of range error when being fed the string output from `fpconv_dtoa()` for a `std::numeric_limits<float>::min()`. This leads to a unit test failure on ARM Linux builds. I am so far unable to come up with a good solution here. Barring writing or integrating a custom string-to-float impl, the best solution seems to be `std::from_chars()` which does work properly in this situation (and is a better solution in other ways, such as ignoring locale settings which is probably what a library like abieos should do).

However, despite being C++17 `std::from_chars<float>()` is only present on libstdc++ 11+, and is still completely absent from the latest libc++ 15! So it appears a non-viable option even in the mid-term.

Changing this to `strtod()` resolves the failure. As @swatanabe has pointed out in a prior conversation on this matter, using `strtod()` here will increase the rounding error should the string encountered in the JSON not be representable as a float. So even though `strtod()` otherwise works on other platforms here, I'll ifdef this workaround to just ARM Linux for now.