### PR TITLE
enlarge buffer for `fpconv_dtoa()` output

### DIFF
--- a/include/eosio/fpconv.c
+++ b/include/eosio/fpconv.c
@@ -308,7 +308,7 @@ static int filter_special(double fp, char* dest)
     return 3;
 }
 
-int fpconv_dtoa(double d, char dest[24])
+int fpconv_dtoa(double d, char dest[25])
 {
     char digits[18];
 

--- a/include/eosio/fpconv.h
+++ b/include/eosio/fpconv.h
@@ -10,8 +10,8 @@
  *
  * Input:
  * fp -> the double to convert, dest -> destination buffer.
- * The generated string will never be longer than 24 characters.
- * Make sure to pass a pointer to at least 24 bytes of memory.
+ * The generated string will never be longer than 24 characters plus a possible '-' character.
+ * Make sure to pass a pointer to at least 25 bytes of memory.
  * The emitted string will not be null terminated.
  *
  * Output:
@@ -21,7 +21,7 @@
  *
  * void print(double d)
  * {
- *      char buf[24 + 1] // plus null terminator
+ *      char buf[25 + 1] // plus null terminator
  *      int str_len = fpconv_dtoa(d, buf);
  *
  *      buf[str_len] = '\0';
@@ -31,9 +31,9 @@
  */
 
 #   ifdef __cplusplus
-extern "C" int fpconv_dtoa(double fp, char dest[24]);
+extern "C" int fpconv_dtoa(double fp, char dest[25]);
 #   else
-int fpconv_dtoa(double fp, char dest[24]);
+int fpconv_dtoa(double fp, char dest[25]);
 #   endif
 
 #endif

--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -150,7 +150,7 @@ void fp_to_json(double value, S& stream) {
    } else if (std::isnan(value)) {
       stream.write("\"NaN\"", 5);
    } else {
-      small_buffer<24> b; // fpconv_dtoa generates at most 24 characters
+      small_buffer<25> b; // fpconv_dtoa generates at most 25 characters
       int              n = fpconv_dtoa(value, b.pos);
       check( n > 0, convert_stream_error(stream_error::float_error) );
       b.pos += n;

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -795,6 +795,8 @@ void check_types() {
     check_type(context, 0, "float64", R"(0.0)", "0");
     check_type(context, 0, "float64", R"(0.125)");
     check_type(context, 0, "float64", R"(-0.125)");
+    check_type(context, 0, "float64", R"(151115727451828646838272.0)", "151115727451828650000000");
+    check_type(context, 0, "float64", R"(-151115727451828646838272.0)", "-151115727451828650000000");
     check_type(context, 0, "float128", R"("00000000000000000000000000000000")");
     check_type(context, 0, "float128", R"("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")");
     check_type(context, 0, "float128", R"("12345678ABCDEF12345678ABCDEF1234")");


### PR DESCRIPTION
For some inputs, `fpconv_dtoa()` will output 25 characters. Resolves #22 