### PR TITLE
Add abieos_delete_contract function

### DIFF
--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -297,3 +297,13 @@ extern "C" const char* abieos_abi_bin_to_json(abieos_context* context, const cha
         return context->result_str.c_str();
     });
 }
+
+extern "C" abieos_bool abieos_delete_contract(abieos_context* context, uint64_t contract) {
+    auto itr = context->contracts.find(::abieos::name{contract});
+    if(itr == context->contracts.end()) {
+        return false;
+    } else {
+        context->contracts.erase(itr);
+        return true;
+    }
+}

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -79,6 +79,9 @@ abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* json);
 // retrieve
 const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size);
 
+// Delete a contract from the context
+abieos_bool abieos_delete_contract(abieos_context* context, uint64_t contract);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
On the node-abieos wrapper version we've include the `abieos_delete_contract` method to improve memory control in long-running cases, such as Hyperion indexing. Having it added to the main abieos will allow us to switch to the vanilla upstream on the node-abieos wrapper and keep it sync with updates in the future