### PR TITLE
Update ship_protocol to use pending_finalizer_policy in finality_data

### DIFF
--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -848,11 +848,11 @@ namespace eosio { namespace ship_protocol {
       uint32_t                        final_on_strong_qc_block_num       = {};
       eosio::checksum256              action_mroot                       = {};
       eosio::checksum256              base_digest                        = {};
-      std::optional<finalizer_policy> proposed_finalizer_policy          = {};
+      std::optional<finalizer_policy> pending_finalizer_policy           = {};
    };
 
    EOSIO_REFLECT(finality_data, major_version, minor_version, active_finalizer_policy_generation,
-                 final_on_strong_qc_block_num, action_mroot, base_digest, proposed_finalizer_policy)
+                 final_on_strong_qc_block_num, action_mroot, base_digest, pending_finalizer_policy)
 
 }} // namespace eosio::ship_protocol
 

--- a/src/ship.abi.cpp
+++ b/src/ship.abi.cpp
@@ -610,7 +610,7 @@ extern const char* const state_history_plugin_abi = R"({
                 { "name": "final_on_strong_qc_block_num", "type": "uint32" },
                 { "name": "action_mroot", "type": "checksum256" },
                 { "name": "base_digest", "type": "checksum256" },
-                { "name": "proposed_finalizer_policy", "type": "finalizer_policy?" }
+                { "name": "pending_finalizer_policy", "type": "finalizer_policy?" }
             ]
         }
     ],


### PR DESCRIPTION
A companion PR to Spring https://github.com/AntelopeIO/spring/pull/322 where `proposed_finalizer_policy` is renamed to `pending_finalizer_policy`.