### PR TITLE
allow nesting of array types in ABI definition, fix "Invalid nesting" cases upon loading ABIs

### DIFF
--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -43,16 +43,17 @@ constexpr void for_each_abi_type(F f) {
     std::apply([&f](auto&& ...t) { (f(&t), ...); }, basic_abi_types{});
 }
 
-abi_type* get_type(std::map<std::string, abi_type>& abi_types,
-                           const std::string& name, int depth) {
-   eosio::check(depth < 32,
-        eosio::convert_abi_error(abi_error::recursion_limit_reached));
+abi_type* get_type(std::map<std::string, abi_type>& abi_types, const std::string& name, int depth) {
+    eosio::check(depth < 32, eosio::convert_abi_error(abi_error::recursion_limit_reached));
     auto it = abi_types.find(name);
     if (it == abi_types.end()) {
         if (ends_with(name, "?")) {
             auto base = get_type(abi_types, name.substr(0, name.size() - 1), depth + 1);
-            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::extension>(base->_data),
-                  eosio::convert_abi_error(abi_error::invalid_nesting));
+            // removed abi_type::array from invalid types for nesting, optional array should work
+            eosio::check(
+                !holds_any_alternative<abi_type::optional, abi_type::extension>(base->_data),
+                "Invalid optional nesting for type: " + name
+            );
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::optional{base}, &abi_serializer_for< ::abieos::pseudo_optional>);
             return &iter->second;
         } else if (ends_with(name, "[]")) {
@@ -60,14 +61,16 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types,
             // removed abi_type::array from invalid types for nesting, array of arrays should work
             eosio::check(
                 !holds_any_alternative<abi_type::optional, abi_type::extension>(element->_data),
-                eosio::convert_abi_error(abi_error::invalid_nesting)
+                "Invalid array nesting for type: " + name
             );
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::array{element}, &abi_serializer_for< ::abieos::pseudo_array>);
             return &iter->second;
         } else if (ends_with(name, "$")) {
             auto base = get_type(abi_types, name.substr(0, name.size() - 1), depth + 1);
-            eosio::check(!std::holds_alternative<abi_type::extension>(base->_data),
-                  eosio::convert_abi_error(abi_error::invalid_nesting));
+            eosio::check(
+                !std::holds_alternative<abi_type::extension>(base->_data),
+                "Invalid extension nesting for type: " + name
+            );
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::extension{base}, &abi_serializer_for< ::abieos::pseudo_extension>);
             return &iter->second;
         } else

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -57,8 +57,11 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types,
             return &iter->second;
         } else if (ends_with(name, "[]")) {
             auto element = get_type(abi_types, name.substr(0, name.size() - 2), depth + 1);
-            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::extension>(element->_data),
-                  eosio::convert_abi_error(abi_error::invalid_nesting));
+            // removed abi_type::array from invalid types for nesting, array of arrays should work
+            eosio::check(
+                !holds_any_alternative<abi_type::optional, abi_type::extension>(element->_data),
+                eosio::convert_abi_error(abi_error::invalid_nesting)
+            );
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::array{element}, &abi_serializer_for< ::abieos::pseudo_array>);
             return &iter->second;
         } else if (ends_with(name, "$")) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1226,6 +1226,18 @@ void check_types() {
     check_checksum_capacity(eosio::checksum256({1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}), 32, "checksum256");
     check_checksum_capacity(eosio::checksum512({1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}), 64, "checksum512");
 
+    // check array of strings
+    check_type(context, 0, "string[]", R"(["hello","world"])");
+
+    // check string[][]
+    check_type(context, 0, "string[][]", R"([["A"],["B"],["C","D"]])");
+
+    // check uint8[][]
+    check_type(context, 0, "uint8[][]", R"([[1]])");
+
+    // check uint8[][][]
+    check_type(context, 0, "uint8[][][]", R"([[[1,2,3],[4,5,6]],[[7,8,9],[]]])");
+
     abieos_destroy(context);
 }
 


### PR DESCRIPTION
This pull request includes changes to allow nesting of array types. It is a used pattern on contracts deployed in production, so we believe abieos should support it too. Based on the existing test suite, this update didn't break any existing functionality. 

We've also included a basic example to test it on the `node-abieos` repository - https://github.com/eosrio/node-abieos/blob/master/examples/nested.mjs - it uses **@wharfkit/antelope** to encode and **abieos** to decode

Changes to support arrays of arrays:

* [`src/abi.cpp`](diffhunk://#diff-51d7ab37ee836661fd66e3f751279e3e7b24956be60ec91e398207b55975f705L60-R64): Removed `abi_type::array` from the invalid types for nesting, enabling arrays of arrays to work.

New tests for arrays of arrays:

* [`src/test.cpp`](diffhunk://#diff-449353818c178e988c4738b8bf554ee57dff0565aa868b80da0262a65a7db408R1229-R1240): Added some tests to check the functionality of arrays of string arrays and multi-dimensional arrays (`string[][]`, `uint8[][]`, `uint8[][][]`).