### PR TITLE
opt in to cmake policies through 3.31 to silence cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # copyright defined in abieos/LICENSE.txt
 
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.8...3.31)
 project(abieos VERSION 0.1 LANGUAGES CXX C)
 
 set(default_build_type "Release")


### PR DESCRIPTION
Latest version of cmake has started to warn,
```
CMake Deprecation Warning at tests/abieos/CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```
since abieos is expected to integrate in to other projects, don't want to bump the hard minimum like some of spring's other submodules. So opt in for cmake policies through 3.31 to silence the warning.