### PR TITLE
require `name`s be valid Antelope names when parsing from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Binary <> JSON conversion using ABIs. Compatible with languages which can interface to C; see [src/abieos.h](src/abieos.h).
 
-Alpha release. Feedback requested.
+## Important or breaking changes
+`main` branch is considered stable. No explicit releases are made. Important or possibly breaking changes are listed below. View linked PR for additional details.
+* **Janurary 2025 via PR [#37](https://github.com/AntelopeIO/abieos/pull/37)**: When converting from JSON, `name`s must be valid Antelope names (no more than 13 characters, a-z.12345 only, etc). Most use cases are unaffected by this change. Consuming state_history's JSON ABI via state_history's websocket will require a minor change in user code.  
 
 ## Packing transactions
 

--- a/include/eosio/name.hpp
+++ b/include/eosio/name.hpp
@@ -4,7 +4,6 @@
 #include "check.hpp"
 #include "operators.hpp"
 #include "reflection.hpp"
-#include "murmur.hpp"
 #include <string>
 
 namespace eosio {
@@ -140,21 +139,12 @@ struct name {
    }
 };
 
-// TODO this seems weird and the name is misleading
-// and I don't think this has ever been truly constexpr
-inline constexpr uint64_t hash_name( std::string_view str ) {
-   auto r = try_string_to_name_strict(str);
-   if( r ) return r.value();
-   return  murmur64( str.data(), str.size() );
-}
-
 EOSIO_REFLECT(name, value);
 EOSIO_COMPARE(name);
 
 template <typename S>
 void from_json(name& obj, S& stream) {
-   auto r = stream.get_string();
-   obj = name(hash_name(r));
+   obj = name(string_to_name_strict(stream.get_string()));
 }
 
 template <typename S>
@@ -170,7 +160,6 @@ inline namespace literals {
    template <typename T, T... Str>
    inline constexpr name operator""_n() {
       return name(string_to_name_strict<Str...>()); }
-   inline constexpr name operator""_h(const char* s, size_t) { return name( hash_name(s) ); }
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Prior to this change, when converting from JSON any `name` that was invalid (such as having longer than 13 characters, a disallowed character, etc) would be silently transformed in to a valid name by way of a hash.

This results in surprising behavior at odds with nodeos where if, for example, serializing the following JSON to an eosio.token transfer,
```json
{"from":"bob bob bob","to":"carol","quantity":"2.0000 EOS","memo":"sup"}
```
will succeed. But with the invalid `bob bob bob` name being replaced with some 64-bit hash value.

This PR now enforces that all `name`s be valid Antelope names when converting from JSON. The above JSON will fail to serialize. This new behavior is generally not expected to cause any problems nor need for any changes by code utilizing abieos because the prior silent hashing behavior was never something standardized in the Antelope ecosystem, including nodeos and cdt.

However, there is one rare use case affected: consuming state_history's JSON ABI that is sent over state_history's websocket. This JSON ABI has table names that are not valid names, such as `contract_index64`.

There is no way to access old behavior via abieos' C interface.

For C++, abieos retains the old behavior via `abi_def_nonstrict_table_name` and this can be used to handle state_history's ABI. A C++ state_history client that uses the JSON ABI sent over the websocket might start with something similar to,
```c++
    eosio::abi abi;

    boost::beast::websocket::stream<boost::asio::ip::tcp::socket> stream(ctx);
    boost::asio::connect(stream.next_layer(), resolver.resolve("127.0.0.1", "8080"));
    stream.handshake(statehistory_server, "/");

    boost::beast::flat_buffer abi_buffer;
    stream.read(abi_buffer);
    std::string abi_string((const char*)abi_buffer.data().data(), abi_buffer.data().size());
    eosio::json_token_stream token_stream(abi_string.data());
    eosio::abi_def abidef = eosio::from_json<eosio::abi_def>(token_stream);
    eosio::convert(abidef, abi);
```
simply change the `from_json<>` line to,
```c++
    eosio::abi_def_nonstrict_table_name abidef = eosio::from_json<eosio::abi_def_nonstrict_table_name>(token_stream);
```
and this ABI will load as it did before.

To be clear, this issue arises only when consuming the JSON ABI from the websocket. Simply using the types in `ship_protocol.hpp` (which is oftentimes what a C++ state_history client does) will not be affected and no code changes are needed in such a case.

Closes #31