### PR TITLE
remove alpha wording & ubuntu16 instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Binary <> JSON conversion using ABIs. Compatible with languages which can interface to C; see [src/abieos.h](src/abieos.h).
 
-Alpha release. Feedback requested.
+abieos utilizes a rolling release model: the `main` branch contains the latest fully supported version.
 
 ## Packing transactions
 
@@ -52,22 +52,6 @@ Example transaction data for `abieos_json_to_bin`:
     }],
     "transaction_extensions":[]
 }
-```
-
-## Ubuntu 16.04 with gcc 8.1.0
-
-* Install these. You may have to build them yourself from source or find a PPA. Make them the default.
-  * gcc 8.1.0
-  * cmake 3.11.3
-* `sudo apt install libboost-dev libboost-date-time-dev`
-* remove this from CMakeLists.txt (2 places): `-fsanitize=address,undefined`
-
-```
-mkdir build
-cd build
-cmake ..
-make
-./test
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Example transaction data for `abieos_json_to_bin`:
 }
 ```
 
+## Building & Testing
+```
+mkdir build
+cd build
+cmake ..
+make
+./test
+```
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
abieos is definitely not 'alpha' so reword this to make it clearer that `main` branch is the supported rolling version. Also remove the ubuntu16 stuff since that's outdated