### PR TITLE
add a CI build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  doit:
+    name: 'Build & Test: ${{matrix.cfg.name}}'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cfg: {name: 'macos-intel',       runson: 'macos-13'}
+          - cfg: {name: 'macos-arm',         runson: 'macos-latest'}
+          - cfg: {name: 'gcc-arm',           runson: 'ubuntu-22.04-arm', container: 'ubuntu:noble'}
+          - cfg: {name: 'clang-arm',         runson: 'ubuntu-22.04-arm', container: 'ubuntu:noble',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'}
+          - cfg: {name: 'gcc10',             runson: 'ubuntu-latest',    container: 'debian:bullseye'}
+          - cfg: {name: 'gcc11',             runson: 'ubuntu-latest',    container: 'ubuntu:jammy'}
+          - cfg: {name: 'gcc12',             runson: 'ubuntu-latest',    container: 'debian:bookworm'}
+          - cfg: {name: 'gcc13',             runson: 'ubuntu-latest',    container: 'ubuntu:noble'}
+          - cfg: {name: 'gcc-arch',          runson: 'ubuntu-latest',    container: 'archlinux'}
+          - cfg: {name: 'clang-arch',        runson: 'ubuntu-latest',    container: 'archlinux',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++'}
+          - cfg: {name: 'clang-lto-arch',    runson: 'ubuntu-latest',    container: 'archlinux',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=On'}
+          - cfg: {name: 'clang-libc++-arch', runson: 'ubuntu-latest',    container: 'archlinux',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++'}
+          - cfg: {name: 'clang-UBSAN-arch',  runson: 'ubuntu-latest',    container: 'archlinux',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all"'}
+          - cfg: {name: 'clang-ASAN-arch',   runson: 'ubuntu-latest',    container: 'archlinux',
+                  cmake: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS=-fsanitize=address'}
+    runs-on: ${{matrix.cfg.runson}}
+    container: ${{matrix.cfg.container}}
+    steps:
+      - name: Arch packages
+        if: matrix.cfg.container == 'archlinux'
+        run: pacman --noconfirm -Syu && pacman --noconfirm -S base-devel cmake git clang llvm libc++
+      - name: Debian/Ubuntu packages
+        if: startsWith(matrix.cfg.container, 'debian') || startsWith(matrix.cfg.container, 'ubuntu')
+        run: apt-get update && apt-get -y upgrade && apt-get -y install build-essential clang cmake git
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        run: cmake -B build ${{matrix.cfg.cmake}} && cmake --build build -j
+      - name: Test
+        run: cd build && ctest --output-on-failure


### PR DESCRIPTION
We do test abieos as part of spring but it's probably a good practice to set up CI here along with branch protection and such. Also more feasible to test on more architectures and configurations here too. (I tried adding MSVC but huh it doesn't support `__int128`! Maybe one day they'll support `_BitInt`)

It might be interesting to explore commonizing this simple workflow across all spring submodules (abieos, appbase, chainbase, bn256, bls, etc) to reduce the duplication and improve consistency. This version has the most yet, including both x86 & ARM macos builds and ARM Linux builds too.