### PR TITLE
Add support for fixed sized arrays

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -206,8 +206,7 @@ struct abi_type {
       std::vector<abi_field> fields;
    };
    using variant = std::vector<abi_field>;
-   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array,
-                fixed_array, struct_, variant>
+   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array, struct_, variant, fixed_array>
                          _data;
    const abi_serializer* ser = nullptr;
 

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -70,9 +70,10 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types, const std::string
             // fixed_array
             int size = 0;
             if (auto idx = name.find_last_of('['); idx != std::string::npos) {
-                auto fc_res = std::from_chars(&name[idx + 1], &name[name.size() - 1], size);
+                const char* last = &name[name.size() - 1];
+                auto fc_res = std::from_chars(&name[idx + 1], last, size);
                 check (fc_res.ec == std::errc{}, "Unexpected size specification for fixed array type");
-                check(fc_res.ptr == &name[name.size() - 1], "Unexpected size specification for fixed array type");
+                check(fc_res.ptr == last, "Unexpected size specification for fixed array type");
                 if (size <= 0) {
                     eosio::check(size != 0, "Zero size fixed arrays not allowed");
                     eosio::check(size > 0, "Negative size fixed arrays not allowed");

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -1,3 +1,4 @@
+#include <charconv>
 #include <eosio/abi.hpp>
 #include "abieos.hpp"
 
@@ -65,6 +66,21 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types, const std::string
             );
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::array{element}, &abi_serializer_for< ::abieos::pseudo_array>);
             return &iter->second;
+        } else if (ends_with(name, "]")) {
+            // fixed_array
+            size_t size = 0;
+            if (auto idx = name.find_last_of('[');
+                idx != std::string::npos &&
+                std::from_chars(&name[idx + 1], &name[name.size() - 1], size).ec == std::errc{}) {
+                auto element = get_type(abi_types, name.substr(0, idx), depth + 1);
+                // removed abi_type::array from invalid types for nesting, array of arrays should work
+                eosio::check(!holds_any_alternative<abi_type::optional, abi_type::extension>(element->_data),
+                             "Invalid array nesting for type: " + name);
+                auto [iter, success] = abi_types.try_emplace(name, name, abi_type::fixed_array{element, size},
+                                                             &abi_serializer_for<::abieos::pseudo_fixed_array>);
+                return &iter->second;
+            } else
+                eosio::check(false, eosio::convert_abi_error(abi_error::unknown_type));
         } else if (ends_with(name, "$")) {
             auto base = get_type(abi_types, name.substr(0, name.size() - 1), depth + 1);
             eosio::check(
@@ -204,6 +220,7 @@ void eosio::convert(const abi_def& abi, eosio::abi& c) {
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::builtin&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::optional&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::array&) {}
+void to_abi_def(abi_def& def, const std::string& name, const abi_type::fixed_array&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::extension&) {}
 
 template<typename T>
@@ -249,6 +266,7 @@ void eosio::convert(const eosio::abi& abi, eosio::abi_def& def) {
 const abi_serializer* const eosio::object_abi_serializer = &abi_serializer_for< ::abieos::pseudo_object>;
 const abi_serializer* const eosio::variant_abi_serializer = &abi_serializer_for< ::abieos::pseudo_variant>;
 const abi_serializer* const eosio::array_abi_serializer = &abi_serializer_for< ::abieos::pseudo_array>;
+const abi_serializer* const eosio::fixed_array_abi_serializer = &abi_serializer_for< ::abieos::pseudo_fixed_array>;
 const abi_serializer* const eosio::extension_abi_serializer = &abi_serializer_for< ::abieos::pseudo_extension>;
 const abi_serializer* const eosio::optional_abi_serializer = &abi_serializer_for< ::abieos::pseudo_optional>;
 

--- a/src/abieos.hpp
+++ b/src/abieos.hpp
@@ -62,6 +62,7 @@ struct pseudo_optional;
 struct pseudo_extension;
 struct pseudo_object;
 struct pseudo_array;
+struct pseudo_fixed_array;
 struct pseudo_variant;
 
 // !!!
@@ -322,12 +323,16 @@ void json_to_bin(pseudo_object*, jvalue_to_bin_state& state, bool allow_extensio
                                 const abi_type* type, bool start);
 void json_to_bin(pseudo_array*, jvalue_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
+void json_to_bin(pseudo_fixed_array*, jvalue_to_bin_state& state, bool allow_extensions,
+                                const abi_type* type, bool start);
 void json_to_bin(pseudo_variant*, jvalue_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
 
 void json_to_bin(pseudo_object*, json_to_bin_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void json_to_bin(pseudo_array*, json_to_bin_state& state, bool allow_extensions, const abi_type* type,
+                                bool start);
+void json_to_bin(pseudo_fixed_array*, json_to_bin_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void json_to_bin(pseudo_variant*, json_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
@@ -339,6 +344,8 @@ void bin_to_json(pseudo_extension*, bin_to_json_state& state, bool allow_extensi
 void bin_to_json(pseudo_object*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void bin_to_json(pseudo_array*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
+                                bool start);
+void bin_to_json(pseudo_fixed_array*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void bin_to_json(pseudo_variant*, bin_to_json_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
@@ -683,6 +690,34 @@ inline void json_to_bin(pseudo_array*, jvalue_to_bin_state& state, bool, const a
     return t->ser->json_to_bin(state, false, t, true);
 }
 
+inline void json_to_bin(pseudo_fixed_array*, jvalue_to_bin_state& state, bool, const abi_type* type,
+                        bool start) {
+    const abi_type::fixed_array* fa = type->as_fixed_array();
+    if (start) {
+        eosio::check(!(!state.received_value || !std::holds_alternative<jarray>(state.received_value->value)),
+                     eosio::convert_json_error(eosio::from_json_error::expected_start_array));
+        auto& value {std::get<jarray>(state.received_value->value)};
+        if (trace_jvalue_to_bin)
+            printf("%*s[ %d elements\n", int(state.stack.size() * 4), "", int(value.size()));
+        eosio::check(value.size() == fa->size, "incorrect size for fixed array");
+        state.stack.push_back({type, false, state.received_value, -1});
+    }
+    auto& stack_entry = state.stack.back();
+    auto& arr = std::get<jarray>(stack_entry.value->value);
+    ++stack_entry.position;
+    if (stack_entry.position == (int)arr.size()) {
+        if (trace_jvalue_to_bin)
+            printf("%*s]\n", int((state.stack.size() - 1) * 4), "");
+        state.stack.pop_back();
+        return;
+    }
+    state.received_value = &arr[stack_entry.position];
+    if (trace_jvalue_to_bin)
+        printf("%*sitem\n", int(state.stack.size() * 4), "");
+    const abi_type* t = type->fixed_array_of();
+    t->ser->json_to_bin(state, false, t, true);
+}
+
 inline void json_to_bin(pseudo_variant*, jvalue_to_bin_state& state, bool allow_extensions,
                                        const abi_type* type, bool start) {
     if (start) {
@@ -842,6 +877,31 @@ inline void json_to_bin(pseudo_array*, json_to_bin_state& state, bool, const abi
     t->ser->json_to_bin(state, false, t, true);
 }
 
+inline void json_to_bin(pseudo_fixed_array*, json_to_bin_state& state, bool, const abi_type* type,
+                        bool start) {
+    if (start) {
+        state.get_start_array();
+        if (trace_json_to_bin)
+            printf("%*s[\n", int(state.stack.size() * 4), "");
+        state.stack.push_back({type, false});
+        return;
+    }
+    auto& stack_entry = state.stack.back();
+    if (state.get_end_array_pred()) {
+        if (trace_json_to_bin)
+            printf("%*s]\n", int((state.stack.size() - 1) * 4), "");
+        const abi_type::fixed_array* fa = type->as_fixed_array();
+        eosio::check(stack_entry.position + 1 == (int)fa->size, "incorrect size for fixed array");
+        state.stack.pop_back();
+        return;
+    }
+    ++stack_entry.position;
+    if (trace_json_to_bin)
+        printf("%*sitem\n", int(state.stack.size() * 4), "");
+    const abi_type* t = type->fixed_array_of();
+    t->ser->json_to_bin(state, false, t, true);
+}
+
 inline void json_to_bin(pseudo_variant*, json_to_bin_state& state, bool allow_extensions,
                                        const abi_type* type, bool start) {
     if (start) {
@@ -974,6 +1034,31 @@ inline void bin_to_json(pseudo_array*, bin_to_json_state& state, bool, const abi
         return state.writer.write(']');
     }
 }
+
+inline void bin_to_json(pseudo_fixed_array*, bin_to_json_state& state, bool, const abi_type* type,
+                        bool start) {
+    const abi_type::fixed_array* fa = type->as_fixed_array();
+    if (start) {
+        state.stack.push_back({type, false});
+        if (trace_bin_to_json)
+            printf("%*s[ %d items\n", int(state.stack.size() * 4), "", int(fa->size));
+        return state.writer.write('[');
+    }
+    auto& stack_entry = state.stack.back();
+    if (++stack_entry.position < int(fa->size)) {
+        if (trace_bin_to_json)
+            printf("%*sitem %d/%d %p %s\n", int(state.stack.size() * 4), "", int(stack_entry.position),
+                   int(fa->size), type->fixed_array_of()->ser, type->fixed_array_of()->name.c_str());
+        if (stack_entry.position != 0) { state.writer.write(','); }
+        return bin_to_json(state, false, type->fixed_array_of(), true);
+    } else {
+        if (trace_bin_to_json)
+            printf("%*s]\n", int((state.stack.size()) * 4), "");
+        state.stack.pop_back();
+        return state.writer.write(']');
+    }
+}
+
 
 inline void bin_to_json(pseudo_variant*, bin_to_json_state& state, bool allow_extensions,
                                          const abi_type* type, bool start) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1048,6 +1048,17 @@ void check_types() {
     check_error(context, "array ([]) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$[11]", ""); });
 
+    check_error(context, "Zero size fixed arrays not allowed",
+                [&] { return abieos_json_to_bin(context, 0, "int8[0]", ""); }, true);
+    check_error(context, "Negative size fixed arrays not allowed",
+                [&] { return abieos_json_to_bin(context, 0, "int8[-1]", ""); }, true);
+    check_error(context, "Unexpected size specification for fixed array type",
+                [&] { return abieos_json_to_bin(context, 0, "int8[0x5]", ""); }, true);
+    check_error(context, "Unexpected size specification for fixed array type",
+                [&] { return abieos_json_to_bin(context, 0, "int8[+5]", ""); }, true);
+    check_error(context, "Leading zeros not allowed for fixed array lengrh specification",
+                [&] { return abieos_json_to_bin(context, 0, "int8[010]", ""); }, true);
+
     check_error(context, "binary extensions ($) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$$", ""); });
     check_error(context, "unknown type \"fee\"", [&] { return abieos_json_to_bin(context, 0, "fee", ""); });

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -132,6 +132,24 @@ const char testAbi[] = R"({
                     "type": "bitset"
                 }
             ]
+        },
+        {
+            "name": "s8",
+            "fields": [
+                {
+                    "name": "a1",
+                    "type": "int8[2]"
+                }
+            ]
+        },
+        {
+            "name": "s9",
+            "fields": [
+                {
+                    "name": "a1",
+                    "type": "s1[2]"
+                }
+            ]
         }
     ],
     "variants": [
@@ -564,12 +582,12 @@ void run_check_type(abieos_context* context, uint64_t contract, const char* type
 }
 
 template <typename F>
-void check_except(const std::string& s, F f) {
+void check_except(const std::string& s, F f, bool check_message) {
     bool ok = false;
     try {
         f();
     } catch (std::exception& e) {
-        if (e.what() == s || true) // !!! Don't check the message right now.  It's in flux.
+        if (e.what() == s || !check_message) // !!! Don't check the message right now.  It's in flux.
             ok = true;
         else
             throw std::runtime_error("expected exception: " + s + " got: " + e.what());
@@ -579,8 +597,8 @@ void check_except(const std::string& s, F f) {
 }
 
 template <typename F>
-void check_error(abieos_context* context, const std::string& s, F f) {
-    check_except(s, [&] { check_context(context, f()); });
+void check_error(abieos_context* context, const std::string& s, F f, bool check_message=false) {
+   check_except(s, [&] { check_context(context, f()); }, check_message);
 }
 
 void check_types() {
@@ -703,6 +721,9 @@ void check_types() {
     check_type(context, 0, "uint8[]", R"([10])");
     check_type(context, 0, "uint8[]", R"([10,9])");
     check_type(context, 0, "uint8[]", R"([10,9,8])");
+    check_type(context, 0, "uint8[1]", R"([10])");
+    check_type(context, 0, "uint8[2]", R"([10,9])");
+    check_type(context, 0, "uint8[3]", R"([10,9,8])");
     check_type(context, 0, "int16", R"(0)");
     check_type(context, 0, "int16", R"(32767)");
     check_type(context, 0, "int16", R"(-32768)");
@@ -972,6 +993,8 @@ void check_types() {
     check_type(context, 0, "asset[]", R"([])");
     check_type(context, 0, "asset[]", R"(["0 FOO"])");
     check_type(context, 0, "asset[]", R"(["0 FOO","0.000 FOO"])");
+    check_type(context, 0, "asset[1]", R"(["0 FOO"])");
+    check_type(context, 0, "asset[2]", R"(["0 FOO","0.000 FOO"])");
     check_type(context, 0, "asset?", R"(null)");
     check_type(context, 0, "asset?", R"("0.123456 SIX")");
     check_type(context, 0, "extended_asset", R"({"quantity":"0 FOO","contract":"bar"})");
@@ -1012,10 +1035,19 @@ void check_types() {
                 [&] { return abieos_json_to_bin(context, 0, "int8?[]", ""); });
     check_error(context, "optional (?) and array ([]) don't support nesting",
                 [&] { return abieos_json_to_bin(context, 0, "int8[]?", ""); });
+
+    check_error(context, "optional (?) and fixed_array ([]) don't support nesting",
+                [&] { return abieos_json_to_bin(context, 0, "int8?[1]", "1"); });
+    check_error(context, "optional (?) and fixed_array ([]) don't support nesting",
+                [&] { return abieos_json_to_bin(context, 0, "int8[1]?", "1"); });
+
     check_error(context, "optional (?) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$?", ""); });
     check_error(context, "array ([]) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$[]", ""); });
+    check_error(context, "array ([]) may not contain binary extensions ($)",
+                [&] { return abieos_json_to_bin(context, 0, "int8$[11]", ""); });
+
     check_error(context, "binary extensions ($) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$$", ""); });
     check_error(context, "unknown type \"fee\"", [&] { return abieos_json_to_bin(context, 0, "fee", ""); });
@@ -1199,6 +1231,20 @@ void check_types() {
             context, testAbiName, "s5",
             R"({"x1":9,"x2":10,"x3":{"c1":4,"c2":[{"x1":7,"x2":true,"x3":{"c1":0,"c2":[],"c3":7}},{"x1":null} ]}} )");
     });
+
+    check_error(context, "expected object", [&] { return abieos_json_to_bin(context, testAbiName, "s8", "null"); });
+    check_error(context, "expected object", [&] { return abieos_json_to_bin(context, testAbiName, "s8", "[]"); });
+    check_error(context, "incorrect size for fixed array",
+                [&] { return abieos_json_to_bin(context, testAbiName, "s8", R"({"a1":[]})"); }, true);
+    check_error(context, "incorrect size for fixed array",
+                [&] { return abieos_json_to_bin(context, testAbiName, "s8", R"({"a1":[1]})"); }, true);
+    check_error(context, "Expected [",
+                [&] { return abieos_json_to_bin(context, testAbiName, "s8", R"({"a1":2})"); }, true);
+    check_error(context, "Expected [",
+                [&] { return abieos_json_to_bin(context, testAbiName, "s8", R"({"a1":true})"); }, true);
+    check_type(context, testAbiName, "s8", R"({"a1":[1,27]})");
+    check_type(context, testAbiName, "s9", R"({"a1":[{"x1":6},{"x1":16}]})");
+
 
     auto testWith = [&](auto& abiName) {
         check_type(context, abiName, "v1", R"(["int8",7])");

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1048,6 +1048,8 @@ void check_types() {
     check_error(context, "array ([]) may not contain binary extensions ($)",
                 [&] { return abieos_json_to_bin(context, 0, "int8$[11]", ""); });
 
+    check_error(context, "']' character found without matching '[' in type specification",
+                [&] { return abieos_json_to_bin(context, 0, "int80]", ""); }, true);
     check_error(context, "Zero size fixed arrays not allowed",
                 [&] { return abieos_json_to_bin(context, 0, "int8[0]", ""); }, true);
     check_error(context, "Negative size fixed arrays not allowed",


### PR DESCRIPTION
Resolves #45.

Implement fixed sized arrays as specified in
https://github.com/AntelopeIO/spring/wiki/ABI-1.3:-Fixed-sized-arrays

See also AntelopeIO/spring#1401 & AntelopeIO/cdt#338